### PR TITLE
Write metadata for sync processes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 .env
 .vscode/settings.json
 .data/*
+plugins
+plguins/*

--- a/context.jsonld
+++ b/context.jsonld
@@ -1,0 +1,32 @@
+{
+    "@context": {
+        "aorc": "https://ckan.dewberryanalytics.com/dataset/49c0ed12-9efa-4da2-bbb8-cc249a63a06e/resource/cb78eea5-95c7-4551-afb6-fbf824c948b8/download/aorc.ttl",
+        "dct": "http://purl.org/dc/terms/",
+        "prov": "https://www.w3.org/ns/prov#",
+        "schema": "https://schema.org/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "apiUser": {
+            "@id": "schema:email",
+            "@type": "xsd:string"
+        },
+        "apiJobId": {
+            "@id": "schema:identifier",
+            "@type": "xsd:string"
+        },
+        "startedAtTime": "prov:startedAtTime",
+        "endedAtTime": "prov:endedAtTime",
+        "generatedAtTime": "prov:generatedAtTime",
+        "process": {
+            "@type": "schema:SoftwareApplication*",
+            "@id": "@type"
+        },
+        "processID": "schema:name",
+        "processVersion": "schema:version",
+        "image": {
+            "@type": "aorc:DockerImgae*",
+            "@id": "@type"
+        },
+        "imageDigest": "aorc:hash",
+        "containerCommands": "aorc:commands"
+    }
+}

--- a/controllers/aws_batch.go
+++ b/controllers/aws_batch.go
@@ -61,46 +61,47 @@ func (c *AWSBatchController) JobCreate(ctx context.Context,
 	return aws.StringValue(output.JobId), nil
 }
 
-// Get current status of the job from Batch and formats it according to OGC Specs, also get LogStreamName
-func (c *AWSBatchController) JobMonitor(batchID string) (string, string, error) {
+// Get current status of the job from Batch and formats it according to OGC Specs, also get LogStreamName, imageDigest
+func (c *AWSBatchController) JobMonitor(batchID string) (string, string, string, error) {
 	input := &batch.DescribeJobsInput{Jobs: aws.StringSlice([]string{batchID})}
 	output, err := c.client.DescribeJobs(input)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 	if len(output.Jobs) == 0 {
-		return "", "", fmt.Errorf("no such job: %s", batchID)
+		return "", "", "", fmt.Errorf("no such job: %s", batchID)
 	}
 
 	status := aws.StringValue(output.Jobs[0].Status)
 	lsn := aws.StringValue(output.Jobs[0].Container.LogStreamName)
+	imgDgst := aws.StringValue(output.Jobs[0].Container.Image)
 
 	if status == "FAILED" {
 		reason := aws.StringValue(output.Jobs[0].StatusReason)
 		// Non-standard reason used here to facilitate ogc implementation
 		if reason == "DISMISSED" {
-			return reason, lsn, nil
+			return reason, lsn, "", nil
 		} else {
-			return status, lsn, fmt.Errorf("aws provided StatusReason for failure: %s", reason)
+			return status, lsn, "", fmt.Errorf("aws provided StatusReason for failure: %s", reason)
 		}
 	}
 
 	switch status {
 	case "SUBMITTED":
-		return "ACCCEPTED", lsn, nil
+		return "ACCCEPTED", lsn, "", nil
 	case "PENDING":
-		return "ACCCEPTED", lsn, nil
+		return "ACCCEPTED", lsn, "", nil
 	case "RUNNABLE":
-		return "ACCCEPTED", lsn, nil
+		return "ACCCEPTED", lsn, "", nil
 	case "STARTING":
-		return "RUNNING", lsn, nil
+		return "RUNNING", lsn, "", nil
 	case "RUNNING":
-		return "RUNNING", lsn, nil
+		return "RUNNING", lsn, "", nil
 	case "SUCCEEDED":
-		return "SUCCEEDED", lsn, nil
+		return "SUCCEEDED", lsn, imgDgst, nil
 
 	default:
-		return status, lsn, fmt.Errorf("unrecognized status  %s", status)
+		return status, lsn, "", fmt.Errorf("unrecognized status  %s", status)
 	}
 }
 

--- a/controllers/aws_batch.go
+++ b/controllers/aws_batch.go
@@ -193,13 +193,13 @@ func (c *AWSBatchController) GetImageURI(jobDef string) (string, error) {
 		return "", fmt.Errorf("Did not get an exact match for job definitions")
 	}
 
-	// Retrieve the ImageDigest from the first job definition in the response
+	// Retrieve the Image URI from the first job definition in the response
 	imageURI := aws.StringValue(resp.JobDefinitions[0].ContainerProperties.Image)
 
 	return imageURI, nil
 }
 
-// Get Image URI from Job Definition
+// Get job execution times
 func (c *AWSBatchController) GetJobTimes(batchID string) (cp time.Time, cr time.Time, st time.Time, err error) {
 
 	describeJobsInput := &batch.DescribeJobsInput{

--- a/controllers/aws_batch.go
+++ b/controllers/aws_batch.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -196,4 +197,31 @@ func (c *AWSBatchController) GetImageURI(jobDef string) (string, error) {
 	imageURI := aws.StringValue(resp.JobDefinitions[0].ContainerProperties.Image)
 
 	return imageURI, nil
+}
+
+// Get Image URI from Job Definition
+func (c *AWSBatchController) GetJobTimes(batchID string) (cp time.Time, cr time.Time, st time.Time, err error) {
+
+	describeJobsInput := &batch.DescribeJobsInput{
+		Jobs: []*string{aws.String(batchID)},
+	}
+
+	describeJobsOutput, err := c.client.DescribeJobs(describeJobsInput)
+	if err != nil {
+		return time.Time{}, time.Time{}, time.Time{}, fmt.Errorf("error describing jobs: %s", err)
+	}
+
+	if len(describeJobsOutput.Jobs) > 0 {
+		job := describeJobsOutput.Jobs[0] // Assuming only one job is returned
+
+		// Extract createdAt, startedAt, and completedAt times
+		cr = time.UnixMilli(*job.CreatedAt)
+		st = time.UnixMilli(*job.StartedAt)
+		cp = time.UnixMilli(*job.StoppedAt)
+
+	} else {
+		return time.Time{}, time.Time{}, time.Time{}, fmt.Errorf("no job information found")
+	}
+
+	return cr, st, cp, nil
 }

--- a/controllers/docker.go
+++ b/controllers/docker.go
@@ -209,3 +209,16 @@ func (c *DockerController) RemoveVolume(name string) error {
 
 	return nil
 }
+
+// Get Image Digest from Image URI
+func (c *DockerController) GetImageDigest(imageURI string) (string, error) {
+	ctx := context.Background()
+	imageInspect, _, err := c.cli.ImageInspectWithRaw(ctx, imageURI)
+	if err != nil {
+		return "", err
+	}
+
+	// Get the digest from the image inspect response
+	imageDigest := imageInspect.ID
+	return imageDigest, nil
+}

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -242,7 +242,7 @@ func (rh *RESTHandler) Execution(c echo.Context) error {
 		runtime := p.Runtime.Provider.Type
 		switch runtime {
 		case "aws-batch":
-			md := fmt.Sprintf("%s/%s.json", os.Getenv("S3_DEFAULT_META_DIR"), jobID)
+			md := fmt.Sprintf("%s/%s.json", os.Getenv("S3_META_DIR"), jobID)
 
 			j = &jobs.AWSBatchJob{
 				UUID:             jobID,
@@ -383,6 +383,41 @@ func (rh *RESTHandler) JobResultsHandler(c echo.Context) error {
 
 		default:
 			output := jobResponse{Type: "process", JobID: jobID, Status: (*job).CurrentStatus(), Message: "results not ready", LastUpdate: (*job).LastUpdate()}
+			return c.JSON(http.StatusNotFound, output)
+		}
+
+	}
+	output := errResponse{Message: "jobID not found"}
+	return c.JSON(http.StatusNotFound, output)
+}
+
+func (rh *RESTHandler) JobMetaDataHandler(c echo.Context) error {
+	jobID := c.Param("jobID")
+	if job, ok := rh.JobsCache.Jobs[jobID]; ok {
+		switch (*job).(type) {
+		case *jobs.DockerJob:
+			output := jobResponse{Type: "process", JobID: jobID, Status: (*job).CurrentStatus(), Message: "metadata not exist for sync jobs."}
+			return c.JSON(http.StatusBadRequest, output)
+		}
+
+		switch (*job).CurrentStatus() {
+		case jobs.SUCCESSFUL:
+			md, err := jobs.FetchMeta(rh.S3Svc, (*job).JobID())
+			if err != nil {
+				if err.Error() == "not found" {
+					output := jobResponse{Type: "process", JobID: jobID, Status: (*job).CurrentStatus(), Message: "metadata not found."}
+					return c.JSON(http.StatusInternalServerError, output)
+				}
+				return c.JSON(http.StatusInternalServerError, err.Error())
+			}
+			return c.JSON(http.StatusOK, md)
+
+		case jobs.FAILED, jobs.DISMISSED:
+			output := jobResponse{Type: "process", JobID: jobID, Status: (*job).CurrentStatus(), Message: "job Failed or Dismissed. Metadata only available for successful jobs.", LastUpdate: (*job).LastUpdate()}
+			return c.JSON(http.StatusOK, output)
+
+		default:
+			output := jobResponse{Type: "process", JobID: jobID, Status: (*job).CurrentStatus(), Message: "metadata not ready", LastUpdate: (*job).LastUpdate()}
 			return c.JSON(http.StatusNotFound, output)
 		}
 

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -242,16 +242,7 @@ func (rh *RESTHandler) Execution(c echo.Context) error {
 		runtime := p.Runtime.Provider.Type
 		switch runtime {
 		case "aws-batch":
-			var md string
-			if val, ok := params.Inputs["metaDataLocation"]; ok {
-				if strVal, ok := val.(string); ok {
-					md = strVal
-				} else {
-					return c.JSON(http.StatusBadRequest, errResponse{Message: "metadata location not a valid string"})
-				}
-			} else {
-				md = fmt.Sprintf("%s/%s.json", os.Getenv("S3_DEFAULT_META_DIR"), jobID)
-			}
+			md := fmt.Sprintf("%s/%s.json", os.Getenv("S3_DEFAULT_META_DIR"), jobID)
 
 			j = &jobs.AWSBatchJob{
 				UUID:             jobID,

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -242,13 +242,12 @@ func (rh *RESTHandler) Execution(c echo.Context) error {
 		runtime := p.Runtime.Provider.Type
 		switch runtime {
 		case "aws-batch":
-			messages := []string{}
 			var md string
 			if val, ok := params.Inputs["metaDataLocation"]; ok {
 				if strVal, ok := val.(string); ok {
 					md = strVal
 				} else {
-					messages = append(messages, "metadata location not a valid string")
+					return c.JSON(http.StatusBadRequest, errResponse{Message: "metadata location not a valid string"})
 				}
 			} else {
 				md = fmt.Sprintf("%s/%s.json", os.Getenv("S3_DEFAULT_META_DIR"), jobID)
@@ -264,7 +263,6 @@ func (rh *RESTHandler) Execution(c echo.Context) error {
 				JobName:          p.Runtime.Provider.Name,
 				MetaDataLocation: md,
 				ProcessVersion:   p.Info.Version,
-				APILogs:          messages,
 			}
 		default:
 			return c.JSON(http.StatusBadRequest, errResponse{Message: fmt.Sprintf("unsupported type %s", jobType)})

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -248,7 +248,7 @@ func (rh *RESTHandler) Execution(c echo.Context) error {
 				if strVal, ok := val.(string); ok {
 					md = strVal
 				} else {
-					messages = append(messages, "jobId: %s metadata location not a valid string")
+					messages = append(messages, "metadata location not a valid string")
 				}
 			} else {
 				md = fmt.Sprintf("%s/%s.json", os.Getenv("S3_DEFAULT_META_DIR"), jobID)
@@ -263,6 +263,7 @@ func (rh *RESTHandler) Execution(c echo.Context) error {
 				JobQueue:         p.Runtime.Provider.JobQueue,
 				JobName:          p.Runtime.Provider.Name,
 				MetaDataLocation: md,
+				ProcessVersion:   p.Info.Version,
 				APILogs:          messages,
 			}
 		default:

--- a/jobs/aws_batch_jobs.go
+++ b/jobs/aws_batch_jobs.go
@@ -27,12 +27,13 @@ type AWSBatchJob struct {
 	Status      string `json:"status"`
 	APILogs     []string
 
-	JobDef        string `json:"jobDefinition"`
-	JobQueue      string `json:"jobQueue"`
-	JobName       string `json:"jobName"`
-	EnvVars       map[string]string
-	batchContext  *controllers.AWSBatchController
-	LogStreamName string
+	JobDef           string `json:"jobDefinition"`
+	JobQueue         string `json:"jobQueue"`
+	JobName          string `json:"jobName"`
+	EnvVars          map[string]string
+	batchContext     *controllers.AWSBatchController
+	LogStreamName    string
+	MetaDataLocation string
 }
 
 func (j *AWSBatchJob) JobID() string {
@@ -140,6 +141,7 @@ func (j *AWSBatchJob) Create() error {
 	return nil
 }
 
+// Thid actually does not run a job but only monitors it
 func (j *AWSBatchJob) Run() {
 	c, err := controllers.NewAWSBatchController(os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY"), os.Getenv("AWS_DEFAULT_REGION"))
 	if err != nil {
@@ -154,7 +156,7 @@ func (j *AWSBatchJob) Run() {
 
 	var oldStatus string
 	for {
-		status, logStreamName, err := c.JobMonitor(j.AWSBatchID)
+		status, logStreamName, imgDgst, err := c.JobMonitor(j.AWSBatchID)
 		if err != nil {
 			j.HandleError(err.Error())
 			return
@@ -171,6 +173,7 @@ func (j *AWSBatchJob) Run() {
 				// fetch results here // todo
 				j.NewStatusUpdate(SUCCESSFUL)
 				j.ctxCancel()
+				go j.WriteMeta(imgDgst)
 				return
 			case "DISMISSED":
 				j.NewStatusUpdate(DISMISSED)

--- a/jobs/aws_batch_jobs.go
+++ b/jobs/aws_batch_jobs.go
@@ -27,13 +27,15 @@ type AWSBatchJob struct {
 	Status      string `json:"status"`
 	APILogs     []string
 
-	JobDef           string `json:"jobDefinition"`
-	JobQueue         string `json:"jobQueue"`
-	JobName          string `json:"jobName"`
-	EnvVars          map[string]string
-	batchContext     *controllers.AWSBatchController
-	LogStreamName    string
+	JobDef        string `json:"jobDefinition"`
+	JobQueue      string `json:"jobQueue"`
+	JobName       string `json:"jobName"`
+	EnvVars       map[string]string
+	batchContext  *controllers.AWSBatchController
+	LogStreamName string
+	// MetaData
 	MetaDataLocation string
+	ProcessVersion   string
 }
 
 func (j *AWSBatchJob) JobID() string {
@@ -156,7 +158,7 @@ func (j *AWSBatchJob) Run() {
 
 	var oldStatus string
 	for {
-		status, logStreamName, imgDgst, err := c.JobMonitor(j.AWSBatchID)
+		status, logStreamName, err := c.JobMonitor(j.AWSBatchID)
 		if err != nil {
 			j.HandleError(err.Error())
 			return
@@ -173,7 +175,7 @@ func (j *AWSBatchJob) Run() {
 				// fetch results here // todo
 				j.NewStatusUpdate(SUCCESSFUL)
 				j.ctxCancel()
-				go j.WriteMeta(imgDgst)
+				go j.WriteMeta(c)
 				return
 			case "DISMISSED":
 				j.NewStatusUpdate(DISMISSED)

--- a/jobs/docker_jobs.go
+++ b/jobs/docker_jobs.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 	"unsafe"
@@ -159,7 +160,9 @@ func (j *DockerJob) Run() {
 
 	// Creating new routine so that failure of writing logs does not mean failure of job
 	// This function does not panic
-	go utils.WriteToS3(strings.Join(logs, "\n"), fmt.Sprintf("%s/%s.txt", os.Getenv("S3_LOGS_DIR"), j.UUID), &j.APILogs, "text/plain")
+	expDays, _ := strconv.Atoi(os.Getenv("EXPIRY_DAYS"))
+	textBytes := []byte(strings.Join(logs, "\n"))
+	go utils.WriteToS3(textBytes, fmt.Sprintf("%s/%s.txt", os.Getenv("S3_LOGS_DIR"), j.UUID), &j.APILogs, "text/plain", expDays)
 
 	// If there are error messages remove container before cancelling context inside Handle Error
 	for _, err := range []error{errWait, errLog} {

--- a/jobs/metadata.go
+++ b/jobs/metadata.go
@@ -59,13 +59,14 @@ func (j *AWSBatchJob) WriteMeta(c *controllers.AWSBatchController) {
 	}
 
 	md := metaData{
-		Context:       "http://schema.org/",
-		JobID:         j.UUID,
-		ProcessID:     j.ProcessID(),
-		ImageURI:      imgURI,
-		ImageDigest:   imgDgst,
-		TimeCompleted: j.UpdateTime,
-		Commands:      j.Cmd,
+		Context:        "http://schema.org/",
+		JobID:          j.UUID,
+		ProcessID:      j.ProcessID(),
+		ProcessVersion: j.ProcessVersion,
+		ImageURI:       imgURI,
+		ImageDigest:    imgDgst,
+		TimeCompleted:  j.UpdateTime,
+		Commands:       j.Cmd,
 	}
 
 	jsonBytes, err := json.Marshal(md)

--- a/jobs/metadata.go
+++ b/jobs/metadata.go
@@ -5,7 +5,13 @@ import (
 	"app/utils"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/labstack/gommon/log"
 )
 
 // Define a metaData object
@@ -23,25 +29,19 @@ type metaData struct {
 	TimeCompleted            time.Time
 }
 
-func (j *AWSBatchJob) WriteMeta(cAws *controllers.AWSBatchController) {
+func (j *AWSBatchJob) WriteMeta(c *controllers.AWSBatchController) {
 
 	if j.MetaDataLocation == "" {
 		return
 	}
 
-	imgURI, err := cAws.GetImageURI(j.JobDef)
+	imgURI, err := c.GetImageURI(j.JobDef)
 	if err != nil {
 		j.NewMessage(fmt.Sprintf("error writing metadata: %s", err.Error()))
 		return
 	}
 
-	cD, err := controllers.NewDockerController()
-	if err != nil {
-		j.NewMessage(fmt.Sprintf("error writing metadata: %s", err.Error()))
-		return
-	}
-
-	imgDgst, err := cD.GetImageDigest(imgURI)
+	imgDgst, err := getImageDigest(imgURI)
 	if err != nil {
 		j.NewMessage(fmt.Sprintf("error writing metadata: %s", err.Error()))
 		return
@@ -66,4 +66,84 @@ func (j *AWSBatchJob) WriteMeta(cAws *controllers.AWSBatchController) {
 	utils.WriteToS3(jsonBytes, j.MetaDataLocation, &j.APILogs, "application/json", 0)
 
 	return
+}
+
+// Get image digest
+func getImageDigest(imgURI string) (string, error) {
+	var imgDgst string
+	if strings.Contains(imgURI, "amazonaws.com/") {
+
+		sess, err := session.NewSessionWithOptions(session.Options{
+			SharedConfigState: session.SharedConfigEnable,
+		})
+		if err != nil {
+			return "", err
+		}
+		ecrClient := ecr.New(sess)
+
+		accountID, repositoryName, imgTag, err := parseImgURI(imgURI)
+		if err != nil {
+			return "", err
+		}
+
+		// Retrieve the image details from ECR
+		log.Warn(accountID)
+		log.Warn(repositoryName)
+		log.Warn(imgTag)
+		describeImagesInput := &ecr.DescribeImagesInput{
+			RegistryId:     aws.String(accountID),
+			RepositoryName: aws.String(repositoryName),
+			ImageIds: []*ecr.ImageIdentifier{
+				{
+					ImageTag: aws.String(imgTag),
+				},
+			},
+		}
+
+		describeImagesOutput, err := ecrClient.DescribeImages(describeImagesInput)
+		if err != nil {
+			return "", err
+		}
+
+		// Get the digest from the image details
+		if len(describeImagesOutput.ImageDetails) > 0 {
+			imgDgst = aws.StringValue(describeImagesOutput.ImageDetails[0].ImageDigest)
+		} else {
+			return "", fmt.Errorf("image not found in ECR")
+		}
+	} else { // dockerHub image
+		// this only works with pulled images
+		cD, err := controllers.NewDockerController()
+		if err != nil {
+			return "", err
+		}
+
+		imgDgst, err = cD.GetImageDigest(imgURI)
+		if err != nil {
+			return "", err
+		}
+	}
+	return imgDgst, nil
+}
+
+// Helper function to parse the ECR repository URI
+func parseImgURI(imgURI string) (string, string, string, error) {
+	// Split the repository URI into account ID, repository name, and image tag
+	parts := strings.Split(imgURI, "/")
+	if len(parts) != 2 {
+		return "", "", "", fmt.Errorf("invalid repository URI: %s", imgURI)
+	}
+
+	accountID := strings.Split(parts[0], ".")[0]
+	imageWithTag := parts[1]
+
+	imageParts := strings.SplitN(imageWithTag, ":", 2)
+	if len(imageParts) != 2 {
+		return "", "", "", fmt.Errorf("invalid image tag in repository URI: %s", imgURI)
+	}
+
+	repositoryName := imageParts[0]
+	imageTag := imageParts[1]
+
+	return accountID, repositoryName, imageTag, nil
 }

--- a/jobs/metadata.go
+++ b/jobs/metadata.go
@@ -1,0 +1,49 @@
+package jobs
+
+import (
+	"app/utils"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Define a metaData object
+type metaData struct {
+	Context                  string `json:"@context"`
+	JobID                    string `json:"apiJobId"`
+	User                     string
+	ProcessID                string `json:"apiProcessId"`
+	ProcessVersion           string
+	ImageDigest              string `json:"imageDigest"`
+	ImageURI                 string `json:"imageURI"`
+	ComputeEnvironmentURI    string // ARN
+	ComputeEnvironmentDigest string // required for reproducibility, will need to be custom implemented
+	Commands                 []string
+	TimeCompleted            time.Time
+}
+
+func (j *AWSBatchJob) WriteMeta(imgDgst string) {
+
+	if j.MetaDataLocation == "" {
+		return
+	}
+
+	md := metaData{
+		Context:       "http://schema.org/",
+		JobID:         j.UUID,
+		ProcessID:     j.ProcessID(),
+		ImageDigest:   imgDgst,
+		TimeCompleted: j.UpdateTime,
+		Commands:      j.Cmd,
+	}
+
+	jsonBytes, err := json.Marshal(md)
+	if err != nil {
+		j.NewMessage(fmt.Sprintf("error writing metadata: %s", err.Error()))
+		return
+	}
+
+	utils.WriteToS3(jsonBytes, j.MetaDataLocation, &j.APILogs, "application/json", 0)
+
+	return
+}

--- a/jobs/metadata.go
+++ b/jobs/metadata.go
@@ -17,19 +17,20 @@ import (
 
 // Define a metaData object
 type metaData struct {
-	Context                  string `json:"@context"`
-	JobID                    string `json:"apiJobId"`
-	User                     string
-	ProcessID                string `json:"apiProcessId"`
-	ProcessVersion           string
-	ImageURI                 string `json:"imageURI"`
-	ImageDigest              string `json:"imageDigest"`
-	ComputeEnvironmentURI    string // ARN
-	ComputeEnvironmentDigest string // required for reproducibility, will need to be custom implemented
-	Commands                 []string
-	TimeCompleted            time.Time
+	Context                  string    `json:"@context"`
+	JobID                    string    `json:"apiJobId"`
+	User                     string    `json:"apiUser"`
+	ProcessID                string    `json:"apiProcessId"`
+	ProcessVersion           string    `json:"apiProcessVersion"`
+	ImageURI                 string    `json:"imageURI"`
+	ImageDigest              string    `json:"imageDigest"`
+	ComputeEnvironmentURI    string    // ARN
+	ComputeEnvironmentDigest string    // required for reproducibility, will need to be custom implemented
+	Commands                 []string  `json:"containerCommands"`
+	TimeCompleted            time.Time `json:"timeJobFinished"`
 }
 
+// Write metadata at the job's metadata location
 func (j *AWSBatchJob) WriteMeta(c *controllers.AWSBatchController) {
 
 	if j.MetaDataLocation == "" {
@@ -173,6 +174,7 @@ func getDkrHubImageDigest(imgURI string, arch string) (string, error) {
 		return "", fmt.Errorf("Error parsing JSON: %s\n", err)
 	}
 
+	// Currently it gets just the first image, while there can be more than 1. This is incorrect
 	digest, ok := result[0].(map[string]interface{})["digest"].(string)
 	if !ok {
 		return "", fmt.Errorf("Error retrieving image digest")

--- a/main.go
+++ b/main.go
@@ -101,9 +101,9 @@ func main() {
 	// Jobs
 	e.GET("/jobs", rh.JobsCacheHandler)
 	e.GET("/jobs/:jobID", rh.JobStatusHandler)
-	e.GET("/jobs/:jobID/results", rh.JobResultsHandler) //requires cache
-	e.GET("/jobs/:jobID/logs", rh.JobLogsHandler)       //requires cache
-	e.GET("/jobs/:jobID/logs", rh.JobMetaDataHandler)   //requires cache
+	e.GET("/jobs/:jobID/results", rh.JobResultsHandler)   //requires cache
+	e.GET("/jobs/:jobID/logs", rh.JobLogsHandler)         //requires cache
+	e.GET("/jobs/:jobID/metadata", rh.JobMetaDataHandler) //requires cache
 	e.DELETE("/jobs/:jobID", rh.JobDismissHandler)
 
 	// JobCache Monitor

--- a/main.go
+++ b/main.go
@@ -103,6 +103,7 @@ func main() {
 	e.GET("/jobs/:jobID", rh.JobStatusHandler)
 	e.GET("/jobs/:jobID/results", rh.JobResultsHandler) //requires cache
 	e.GET("/jobs/:jobID/logs", rh.JobLogsHandler)       //requires cache
+	e.GET("/jobs/:jobID/logs", rh.JobMetaDataHandler)   //requires cache
 	e.DELETE("/jobs/:jobID", rh.JobDismissHandler)
 
 	// JobCache Monitor


### PR DESCRIPTION
This PR
- writes metadata.json file for async processes on S3
- creates a context.jsonld document
- provides an endpoint to get metadata of a job.

Sample metadata:

```JSON
{
  "@context": "https://github.com/Dewberry/process-api/blob/main/context.jsonld",
  "apiJobId": "3de2d906-ad90-4036-9345-d143ff8ce3d8",
  "apiUser": "",
  "process": {
    "processId": "ogrVersion",
    "processVersion": "2023.2.1"
  },
  "image": {
    "imageURI": "osgeo/gdal:alpine-small-latest",
    "imageDigest": "sha256:640f4dfba9d7d48b6f66a4ca3436ab0913f7473fad6033125dcb3da940227038"
  },
  "containerCommands": [
    "echo",
    "hello world",
    "{\"expDays\":\"7\",\"jobID\":\"3de2d906-ad90-4036-9345-d143ff8ce3d8\",\"resultsDir\":\"results\"}"
  ],
  "generatedAtTime": "2023-05-17T15:10:05.543-04:00",
  "startedAtTime": "2023-05-17T15:10:29.75-04:00",
  "endedAtTime": "2023-05-17T15:10:52.804-04:00"
}
```