### PR TITLE
Specify and describe resources a process can use

### DIFF
--- a/controllers/docker.go
+++ b/controllers/docker.go
@@ -19,6 +19,8 @@ type DockerController struct {
 	cli *client.Client
 }
 
+type DockerResources container.Resources
+
 func NewDockerController() (*DockerController, error) {
 	c := new(DockerController)
 	var err error
@@ -31,8 +33,11 @@ func NewDockerController() (*DockerController, error) {
 }
 
 // returns container id, error
-func (c *DockerController) ContainerRun(ctx context.Context, image string, command []string, volumes []VolumeMount, envVars map[string]string) (string, error) {
-	hostConfig := container.HostConfig{}
+func (c *DockerController) ContainerRun(ctx context.Context, image string, command []string, volumes []VolumeMount, envVars map[string]string, resources DockerResources) (string, error) {
+	hostConfig := container.HostConfig{
+		Resources: container.Resources(resources),
+	}
+
 	log.Debug("Initialize Container run")
 	//	hostConfig.Mounts = make([]mount.Mount,0);
 

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -234,6 +234,7 @@ func (rh *RESTHandler) Execution(c echo.Context) error {
 			ProcessName: processID,
 			Image:       p.Runtime.Image,
 			EnvVars:     p.Runtime.EnvVars,
+			Resources:   jobs.Resources(p.Runtime.Resources),
 			Cmd:         cmd,
 		}
 

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -222,19 +222,19 @@ func (rh *RESTHandler) Execution(c echo.Context) error {
 	}
 
 	var cmd []string
-	if p.Runtime.Command == nil {
+	if p.Container.Command == nil {
 		cmd = []string{string(jsonParams)}
 	} else {
-		cmd = append(p.Runtime.Command, string(jsonParams))
+		cmd = append(p.Container.Command, string(jsonParams))
 	}
 
 	if jobType == "sync-execute" {
 		j = &jobs.DockerJob{
 			UUID:        jobID,
 			ProcessName: processID,
-			Image:       p.Runtime.Image,
-			EnvVars:     p.Runtime.EnvVars,
-			Resources:   jobs.Resources(p.Runtime.Resources),
+			Image:       p.Container.Image,
+			EnvVars:     p.Container.EnvVars,
+			Resources:   jobs.Resources(p.Container.Resources),
 			Cmd:         cmd,
 		}
 
@@ -247,7 +247,7 @@ func (rh *RESTHandler) Execution(c echo.Context) error {
 			j = &jobs.AWSBatchJob{
 				UUID:             jobID,
 				ProcessName:      processID,
-				Image:            p.Runtime.Image,
+				Image:            p.Container.Image,
 				Cmd:              cmd,
 				JobDef:           p.Host.JobDefinition,
 				JobQueue:         p.Host.JobQueue,

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -232,15 +232,14 @@ func (rh *RESTHandler) Execution(c echo.Context) error {
 		j = &jobs.DockerJob{
 			UUID:        jobID,
 			ProcessName: processID,
-			Repository:  p.Runtime.Repository,
+			Image:       p.Runtime.Image,
 			EnvVars:     p.Runtime.EnvVars,
-			ImgTag:      fmt.Sprintf("%s:%s", p.Runtime.Image, p.Runtime.Tag),
 			Cmd:         cmd,
 		}
 
 	} else {
-		runtime := p.Runtime.Provider.Type
-		switch runtime {
+		host := p.Host.Type
+		switch host {
 		case "aws-batch":
 			var md string
 			if val, ok := params.Inputs["metaDataLocation"]; ok {
@@ -256,11 +255,11 @@ func (rh *RESTHandler) Execution(c echo.Context) error {
 			j = &jobs.AWSBatchJob{
 				UUID:             jobID,
 				ProcessName:      processID,
-				ImgTag:           fmt.Sprintf("%s:%s", p.Runtime.Image, p.Runtime.Tag),
+				Image:            p.Runtime.Image,
 				Cmd:              cmd,
-				JobDef:           p.Runtime.Provider.JobDefinition,
-				JobQueue:         p.Runtime.Provider.JobQueue,
-				JobName:          p.Runtime.Provider.Name,
+				JobDef:           p.Host.JobDefinition,
+				JobQueue:         p.Host.JobQueue,
+				JobName:          "ogc-api-id-" + jobID,
 				MetaDataLocation: md,
 				ProcessVersion:   p.Info.Version,
 			}

--- a/jobs/aws_batch_jobs.go
+++ b/jobs/aws_batch_jobs.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
-	"github.com/labstack/gommon/log"
 )
 
 // Fields are exported so that gob can access it
@@ -21,14 +20,16 @@ type AWSBatchJob struct {
 	UUID        string `json:"jobID"`
 	AWSBatchID  string
 	ProcessName string   `json:"processID"`
-	ImgTag      string   `json:"imageAndTag"`
+	Image       string   `json:"image"`
 	Cmd         []string `json:"commandOverride"`
 	UpdateTime  time.Time
 	Status      string `json:"status"`
 	APILogs     []string
 
-	JobDef        string `json:"jobDefinition"`
-	JobQueue      string `json:"jobQueue"`
+	JobDef   string `json:"jobDefinition"`
+	JobQueue string `json:"jobQueue"`
+
+	// Job Name in Batch for this job
 	JobName       string `json:"jobName"`
 	EnvVars       map[string]string
 	batchContext  *controllers.AWSBatchController
@@ -50,8 +51,8 @@ func (j *AWSBatchJob) CMD() []string {
 	return j.Cmd
 }
 
-func (j *AWSBatchJob) IMGTAG() string {
-	return j.ImgTag
+func (j *AWSBatchJob) IMAGE() string {
+	return j.Image
 }
 
 // Fetches Container logs from CloudWatch and API logs from cache
@@ -121,9 +122,6 @@ func (j *AWSBatchJob) Create() error {
 		return err
 	}
 
-	log.Debug("j.JobDef | ", j.JobDef)
-	log.Debug("j.JobQueue | ", j.JobQueue)
-	log.Debug("j.JobName  | ", j.JobName)
 	aWSBatchID, err := batchContext.JobCreate(j.ctx, j.JobDef, j.JobName, j.JobQueue, j.Cmd, j.EnvVars)
 	if err != nil {
 		j.HandleError(err.Error())
@@ -232,7 +230,7 @@ func (j *AWSBatchJob) GetSizeinCache() int {
 		int(unsafe.Sizeof(j.ctxCancel)) +
 		int(unsafe.Sizeof(j.UUID)) + len(j.UUID) +
 		int(unsafe.Sizeof(j.AWSBatchID)) + len(j.AWSBatchID) +
-		int(unsafe.Sizeof(j.ImgTag)) + len(j.ImgTag) +
+		int(unsafe.Sizeof(j.Image)) + len(j.Image) +
 		int(unsafe.Sizeof(j.UpdateTime)) +
 		int(unsafe.Sizeof(j.Status)) +
 		int(unsafe.Sizeof(j.LogStreamName)) + len(j.LogStreamName) +

--- a/jobs/docker_jobs.go
+++ b/jobs/docker_jobs.go
@@ -24,7 +24,7 @@ type DockerJob struct {
 	UUID        string `json:"jobID"`
 	ContainerID string
 	Repository  string `json:"repository"` // for local repositories leave empty
-	ImgTag      string `json:"imageAndTag"`
+	Image       string `json:"image"`
 	ProcessName string `json:"processID"`
 	EnvVars     []string
 	Cmd         []string `json:"commandOverride"`
@@ -45,8 +45,8 @@ func (j *DockerJob) CMD() []string {
 	return j.Cmd
 }
 
-func (j *DockerJob) IMGTAG() string {
-	return j.ImgTag
+func (j *DockerJob) IMAGE() string {
+	return j.Image
 }
 
 // Fetches Container logs from S3 and API logs from cache
@@ -120,7 +120,7 @@ func (j *DockerJob) Create() error {
 
 	// pull image
 	if j.Repository != "" {
-		err = c.EnsureImage(ctx, j.ImgTag, false)
+		err = c.EnsureImage(ctx, j.Image, false)
 		if err != nil {
 			j.HandleError(err.Error())
 			return err
@@ -146,7 +146,7 @@ func (j *DockerJob) Run() {
 
 	// start container
 	j.NewStatusUpdate(RUNNING)
-	containerID, err := c.ContainerRun(j.ctx, j.ImgTag, j.Cmd, []controllers.VolumeMount{}, envVars)
+	containerID, err := c.ContainerRun(j.ctx, j.Image, j.Cmd, []controllers.VolumeMount{}, envVars)
 	if err != nil {
 		j.HandleError(err.Error())
 		return
@@ -238,7 +238,7 @@ func (j *DockerJob) GetSizeinCache() int {
 		int(unsafe.Sizeof(j.ctxCancel)) +
 		int(unsafe.Sizeof(j.UUID)) + len(j.UUID) +
 		int(unsafe.Sizeof(j.ContainerID)) + len(j.ContainerID) +
-		int(unsafe.Sizeof(j.ImgTag)) + len(j.ImgTag) +
+		int(unsafe.Sizeof(j.Image)) + len(j.Image) +
 		int(unsafe.Sizeof(j.UpdateTime)) +
 		int(unsafe.Sizeof(j.Status))
 	return totalMemory

--- a/jobs/docker_jobs.go
+++ b/jobs/docker_jobs.go
@@ -23,7 +23,6 @@ type DockerJob struct {
 	ctxCancel   context.CancelFunc
 	UUID        string `json:"jobID"`
 	ContainerID string
-	Repository  string `json:"repository"` // for local repositories leave empty
 	Image       string `json:"image"`
 	ProcessName string `json:"processID"`
 	EnvVars     []string
@@ -120,7 +119,7 @@ func (j *DockerJob) Create() error {
 	}
 
 	// pull image
-	if j.Repository != "" {
+	if j.Image != "" {
 		err = c.EnsureImage(ctx, j.Image, false)
 		if err != nil {
 			j.HandleError(err.Error())

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -10,6 +10,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
+type Resources struct {
+	CPUs   float32
+	Memory int
+}
+
 // Job refers to any process that has been created through
 // the processes/{processID}/execution endpoint
 type Job interface {

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -19,7 +19,7 @@ type Job interface {
 	CMD() []string
 	CurrentStatus() string
 	Equals(Job) bool
-	IMGTAG() string
+	IMAGE() string
 	JobID() string
 	ProcessID() string
 	Logs() (JobLogs, error)

--- a/processes/process_describe.go
+++ b/processes/process_describe.go
@@ -11,7 +11,7 @@ type processDescription struct {
 
 func (p process) Describe() (processDescription, error) {
 	pd := processDescription{
-		Info: p.Info, Image: p.Runtime.Image, Resources: p.Runtime.Resources, Inputs: p.Inputs, Outputs: p.Outputs} // Links: p.createLinks()
+		Info: p.Info, Image: p.Container.Image, Resources: p.Container.Resources, Inputs: p.Inputs, Outputs: p.Outputs} // Links: p.createLinks()
 
 	return pd, nil
 }

--- a/processes/process_describe.go
+++ b/processes/process_describe.go
@@ -1,0 +1,17 @@
+package processes
+
+type processDescription struct {
+	Info      `json:"info"`
+	Image     string `json:"image"`
+	Resources `json:"maxResources,omitempty"`
+	Inputs    []Inputs  `json:"inputs"`
+	Outputs   []Outputs `json:"outputs"`
+	Links     []Link    `json:"links"`
+}
+
+func (p process) Describe() (processDescription, error) {
+	pd := processDescription{
+		Info: p.Info, Image: p.Runtime.Image, Resources: p.Runtime.Resources, Inputs: p.Inputs, Outputs: p.Outputs} // Links: p.createLinks()
+
+	return pd, nil
+}

--- a/processes/processes.go
+++ b/processes/processes.go
@@ -20,14 +20,6 @@ type process struct {
 	Outputs []Outputs `yaml:"outputs"`
 }
 
-type processDescription struct {
-	Info      `json:"info"`
-	Resources `json:"maxResources,omitempty"`
-	Inputs    []Inputs  `json:"inputs"`
-	Outputs   []Outputs `json:"outputs"`
-	Links     []Link    `json:"links"`
-}
-
 type Link struct {
 	Href  string `yaml:"href" json:"href"`
 	Rel   string `yaml:"rel,omitempty" json:"rel,omitempty"`
@@ -115,13 +107,6 @@ type Runtime struct {
 // 	}
 // 	return links
 // }
-
-func (p process) Describe() (processDescription, error) {
-	pd := processDescription{
-		Info: p.Info, Resources: p.Runtime.Resources, Inputs: p.Inputs, Outputs: p.Outputs} // Links: p.createLinks()
-
-	return pd, nil
-}
 
 func (p process) Type() string {
 	return p.Host.Type

--- a/processes/processes.go
+++ b/processes/processes.go
@@ -3,6 +3,7 @@
 package processes
 
 import (
+	"app/controllers"
 	"errors"
 	"fmt"
 	"os"
@@ -13,16 +14,18 @@ import (
 
 type process struct {
 	Info    Info      `yaml:"info"`
+	Host    Host      `yaml:"host"`
 	Runtime Runtime   `yaml:"runtime"`
 	Inputs  []Inputs  `yaml:"inputs"`
 	Outputs []Outputs `yaml:"outputs"`
 }
 
 type processDescription struct {
-	Info    `json:"info"`
-	Inputs  []Inputs  `json:"inputs"`
-	Outputs []Outputs `json:"outputs"`
-	Links   []Link    `json:"links"`
+	Info      `json:"info"`
+	Resources `json:"maxResources,omitempty"`
+	Inputs    []Inputs  `json:"inputs"`
+	Outputs   []Outputs `json:"outputs"`
+	Links     []Link    `json:"links"`
 }
 
 type Link struct {
@@ -74,48 +77,54 @@ type Outputs struct {
 	InputID string `yaml:"inputId"` //json omit
 }
 
-// Non-OGC types used for this API's implementation of the standard
-// Runtime provides information on the host calling the container
-type Runtime struct {
-	Repository  string   `yaml:"repository"`
-	Image       string   `yaml:"image"`
-	Tag         string   `yaml:"tag"`
-	Provider    Provider `yaml:"provider"`
-	Description string   `yaml:"description"`
-	EnvVars     []string `yaml:"envVars"`
-	Command     []string `yaml:"command"`
+// Resources
+type Resources struct {
+	VCPUs  float32 `yaml:"vCPUs" json:"vCPUs,omitempty"`
+	Memory int     `yaml:"memory" json:"memory,omitempty"`
 }
 
-// Provider is currently limited to AWS Batch, will require changes
+// Host is currently limited to "local" or "aws-batch", will require changes
 // for extending to additional cloud services (e.g. lambda) or controllers (e.g. Azure)
-type Provider struct {
-	Type          string `yaml:"type"`
+type Host struct {
+	// Type should be one of "local", "aws-batch"
+	Type string `yaml:"type"`
+
+	// Host specific jargon
+	// AWS
 	JobDefinition string `yaml:"jobDefinition"`
 	JobQueue      string `yaml:"jobQueue"`
-	Name          string `yaml:"name"`
 }
 
-func (p process) createLinks() []Link {
-	var links []Link
-	if p.Runtime.Repository != "" {
-		links = append(links, Link{Href: fmt.Sprintf("%s/%s", p.Runtime.Repository, p.Runtime.Image)})
-	}
-	return links
+// Non-OGC types used for this API's implementation of the standard
+
+// Runtime provides information with which to call the container/job
+type Runtime struct {
+	// Image is the exact string which docker can use to pull an image
+	// Image will be overwritten for batch jobs defined by job defitions
+	Image string `yaml:"image"`
+
+	EnvVars   []string  `yaml:"envVars"`
+	Command   []string  `yaml:"command"`
+	Resources Resources `yaml:"maxResources"` // max resources this process can use
 }
+
+// func (p process) createLinks() []Link {
+// 	var links []Link
+// 	if p.Runtime.Image != "" {
+// 		links = append(links, Link{Href: fmt.Sprintf("%s/%s", p.Runtime.Repository, p.Runtime.Image)})
+// 	}
+// 	return links
+// }
 
 func (p process) Describe() (processDescription, error) {
 	pd := processDescription{
-		Info: p.Info, Inputs: p.Inputs, Outputs: p.Outputs, Links: p.createLinks()}
+		Info: p.Info, Resources: p.Runtime.Resources, Inputs: p.Inputs, Outputs: p.Outputs} // Links: p.createLinks()
 
 	return pd, nil
 }
 
 func (p process) Type() string {
-	return p.Runtime.Provider.Type
-}
-
-func (p process) ImgTag() string {
-	return fmt.Sprintf("%s:%s", p.Runtime.Image, p.Runtime.Tag)
+	return p.Host.Type
 }
 
 type inpOccurance struct {
@@ -186,6 +195,24 @@ func newProcess(f string) (process, error) {
 	if err != nil {
 		return process{}, err
 	}
+
+	// if processes is AWS Batch process get its resources, image, etc
+	// the problem with doing this here is that if the job definition is updated while we are doing this, our process info will not update
+	switch p.Host.Type {
+	case "aws-batch":
+		c, err := controllers.NewAWSBatchController(os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY"), os.Getenv("AWS_DEFAULT_REGION"))
+		if err != nil {
+			return process{}, err
+		}
+		jdi, err := c.GetJobDefInfo(p.Host.JobDefinition)
+		if err != nil {
+			return process{}, err
+		}
+		p.Runtime.Image = jdi.Image
+		p.Runtime.Resources.Memory = jdi.Memory
+		p.Runtime.Resources.VCPUs = jdi.VCPUs
+	}
+
 	return p, nil
 }
 

--- a/processes/processes.go
+++ b/processes/processes.go
@@ -79,7 +79,7 @@ type Outputs struct {
 
 // Resources
 type Resources struct {
-	VCPUs  float32 `yaml:"vCPUs" json:"vCPUs,omitempty"`
+	CPUs   float32 `yaml:"cpus" json:"cpus,omitempty"`
 	Memory int     `yaml:"memory" json:"memory,omitempty"`
 }
 
@@ -210,7 +210,7 @@ func newProcess(f string) (process, error) {
 		}
 		p.Runtime.Image = jdi.Image
 		p.Runtime.Resources.Memory = jdi.Memory
-		p.Runtime.Resources.VCPUs = jdi.VCPUs
+		p.Runtime.Resources.CPUs = jdi.VCPUs
 	}
 
 	return p, nil

--- a/processes/processes.go
+++ b/processes/processes.go
@@ -13,11 +13,11 @@ import (
 )
 
 type process struct {
-	Info    Info      `yaml:"info"`
-	Host    Host      `yaml:"host"`
-	Runtime Runtime   `yaml:"runtime"`
-	Inputs  []Inputs  `yaml:"inputs"`
-	Outputs []Outputs `yaml:"outputs"`
+	Info      Info      `yaml:"info"`
+	Host      Host      `yaml:"host"`
+	Container Container `yaml:"container"`
+	Inputs    []Inputs  `yaml:"inputs"`
+	Outputs   []Outputs `yaml:"outputs"`
 }
 
 type Link struct {
@@ -89,8 +89,8 @@ type Host struct {
 
 // Non-OGC types used for this API's implementation of the standard
 
-// Runtime provides information with which to call the container/job
-type Runtime struct {
+// Container provides information with which to call the container/job
+type Container struct {
 	// Image is the exact string which docker can use to pull an image
 	// Image will be overwritten for batch jobs defined by job defitions
 	Image string `yaml:"image"`
@@ -102,8 +102,8 @@ type Runtime struct {
 
 // func (p process) createLinks() []Link {
 // 	var links []Link
-// 	if p.Runtime.Image != "" {
-// 		links = append(links, Link{Href: fmt.Sprintf("%s/%s", p.Runtime.Repository, p.Runtime.Image)})
+// 	if p.Container.Image != "" {
+// 		links = append(links, Link{Href: fmt.Sprintf("%s/%s", p.Container.Repository, p.Container.Image)})
 // 	}
 // 	return links
 // }
@@ -193,9 +193,9 @@ func newProcess(f string) (process, error) {
 		if err != nil {
 			return process{}, err
 		}
-		p.Runtime.Image = jdi.Image
-		p.Runtime.Resources.Memory = jdi.Memory
-		p.Runtime.Resources.CPUs = jdi.VCPUs
+		p.Container.Image = jdi.Image
+		p.Container.Resources.Memory = jdi.Memory
+		p.Container.Resources.CPUs = jdi.VCPUs
 	}
 
 	return p, nil

--- a/template_process.yaml
+++ b/template_process.yaml
@@ -1,0 +1,58 @@
+info:
+  # version should follow sementic versioning `MAJOR.MINOR.PATCH` for details: https://semver.org/
+  version: '0.0.1'
+  # UUID for this process, it should follow camelCase format
+  id: aepGrid
+  # human friendly name of the process
+  title: AEP Grid
+  # describe what this process does in a line or two
+  description: Creates an Annual Exceedence Probability (AEP) grid
+  # available job control options, must be from [sync-execute, async-execute]
+  jobControlOptions:
+    - async-execute
+  # types of outputs that this process generate, must be from [reference, value, ]
+  outputTransmission:
+    - reference
+
+# host are execution plateforms such as, 'local' or 'aws-batch'
+# fields that are not related to a particular host can be omitted, for example jobDefinition, jobQueue not required for 'local' host
+host:
+  type: "aws-batch"
+  jobDefinition: process-sandbox:2
+  jobQueue: micro-test
+
+runtime:
+  # full uri of the image, it should be exectly same as what is needed in docker pull command
+  # image should be empty when image is defined somewhere else, for example in jobDefinition
+  # in that case the, the API will fetch this information at the startup and overwrite image information
+  image: ""
+  # entrypoint for the container
+  command:
+    - python
+    - aep_blocks.py
+  # env variable keys that need to be passed to container, for AWS_ACCESS_KEY_ID etc
+  # should be left empty for cloud processes and defined in jobDefinition
+  envVars:
+    - variable1
+    - variable2
+
+# inputs user must provide
+inputs:
+  - id: tile
+    title: tile
+    input:
+      literalDataDomain:
+        dataType: string
+        valueDefinition:
+          anyValue: true
+    minOccurs: 1
+    maxOccurs: 1
+
+# outputs user should expect after successful run
+outputs:
+  - id: aepGrid
+    title: aepGrid
+    inputId: aepGridDestination
+    output:
+      transmissionMode:
+      - reference

--- a/template_process.yaml
+++ b/template_process.yaml
@@ -21,7 +21,7 @@ host:
   jobDefinition: process-sandbox:2
   jobQueue: micro-test
 
-runtime:
+container:
   # full uri of the image, it should be exectly same as what is needed in docker pull command
   # image should be empty when image is defined somewhere else, for example in jobDefinition
   # in that case the, the API will fetch this information at the startup and overwrite image information

--- a/template_process.yaml
+++ b/template_process.yaml
@@ -30,6 +30,14 @@ runtime:
   command:
     - python
     - aep_blocks.py
+  # max resources this container can use
+  # should be left empty for cloud processes where this information is defined in cloud job configuration
+  # in that case the, the API will fetch this information at the startup and overwrite these properties
+  maxResources:
+    # cpus in fraction for example, 0.5 would mean use 0.5 CPUs
+    cpus: 0.1
+    # memory in megabytes
+    memory: 1024
   # env variable keys that need to be passed to container, for AWS_ACCESS_KEY_ID etc
   # should be left empty for cloud processes and defined in jobDefinition
   envVars:


### PR DESCRIPTION
This PR:

- Adds functionality to get resources information from AWS Batch given a job definition
- Run the docker containers with the max allowed resources specified in the process.yaml
- Revise processes yaml format to separate host and group image information together
- Add am example template for processes to create the configuration yaml file.