### PR TITLE
Fix CloudWatch latency issue

### DIFF
--- a/api/jobs/aws_batch_jobs.go
+++ b/api/jobs/aws_batch_jobs.go
@@ -363,6 +363,7 @@ func (j *AWSBatchJob) Close() {
 	// to do: add panic recover to remove job from active jobs even if following panics
 	j.ctxCancel()
 
+	time.Sleep(2 * time.Second) // It can take a few moments for logs to be delivered to CloudWatch
 	err := j.fetchCloudWatchLogs()
 	if err != nil {
 		j.NewMessage("Could not fetch cloud watch logs. Error: " + err.Error())

--- a/api/jobs/aws_batch_jobs.go
+++ b/api/jobs/aws_batch_jobs.go
@@ -204,7 +204,9 @@ func (j *AWSBatchJob) Kill() error {
 	// If a dismiss status is updated the job is considered dismissed at this point
 	// Close being graceful or not does not matter.
 
-	defer j.Close()
+	defer func() {
+		go j.Close()
+	}()
 	return nil
 }
 

--- a/api/jobs/docker_jobs.go
+++ b/api/jobs/docker_jobs.go
@@ -235,7 +235,9 @@ func (j *DockerJob) Kill() error {
 	// If a dismiss status is updated the job is considered dismissed at this point
 	// Close being graceful or not does not matter.
 
-	defer j.Close()
+	defer func() {
+		go j.Close()
+	}()
 	return nil
 }
 

--- a/api/main.go
+++ b/api/main.go
@@ -133,7 +133,7 @@ func main() {
 	if err := rh.ActiveJobs.KillAll(); err != nil {
 		e.Logger.Error(err)
 	} else {
-		e.Logger.Info("killed and removed active containers")
+		e.Logger.Info("kill command sent to all active jobs")
 	}
 
 	time.Sleep(15 * time.Second) // sleep so that routines spawned by KillAll() can finish, using 15 seconds because AWS batch monitors jobs every 10 seconds


### PR DESCRIPTION
@slawler Not all logs are being captured before we close AWS jobs. My guess is that it is because of the latency in log events to be delivered to Cloudwatch. Basically, the job successful event is being delivered to Process API before all log events are captured by Cloudwatch.

Can you confirm this patch works on the VAP server?

This should have all the logs, the last few logs are missing.
![image](https://github.com/Dewberry/process-api/assets/53625184/4074f6e0-78d5-4c71-9fda-8467fd38d0fb)
