### PR TITLE
Write logs to storage

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,7 +1,7 @@
 # -------------------------------
 FROM golang:1.19.12 AS dev
 
-RUN go install github.com/swaggo/swag/cmd/swag@v1.8.12
+# RUN go install github.com/swaggo/swag/cmd/swag@v1.8.12
 
 # Hot-Reloader
 RUN go install github.com/githubnemo/CompileDaemon@v1.4.0
@@ -9,7 +9,7 @@ RUN go install github.com/githubnemo/CompileDaemon@v1.4.0
 COPY ./ /app
 WORKDIR /app
 
-RUN swag init && go build main.go
+# RUN swag init && go build main.go
 
 ENTRYPOINT ["CompileDaemon", "--build=go build main.go", "--command=./main"]
 # -------------------------------

--- a/api/go.mod
+++ b/api/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/labstack/echo/v4 v4.10.2
 	github.com/labstack/gommon v0.4.0
+	github.com/sirupsen/logrus v1.7.0
 	github.com/swaggo/echo-swagger v1.3.5
 	github.com/swaggo/swag v1.8.1
 	gopkg.in/yaml.v3 v3.0.1

--- a/api/go.sum
+++ b/api/go.sum
@@ -104,11 +104,14 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
+github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -170,6 +173,7 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/api/handlers/config.go
+++ b/api/handlers/config.go
@@ -93,6 +93,16 @@ func NewRESTHander(pluginsDir string, dbPath string) *RESTHandler {
 	}
 	config.StorageSvc = stSvc
 
+	// Create local logs directory if not exist
+	localLogsDir, exist := os.LookupEnv("LOCAL_LOGS_DIR")
+	if !exist {
+		log.Fatal("env variable LOCAL_LOGS_DIR not set")
+	}
+	err = os.MkdirAll(localLogsDir, 0755)
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+
 	// Setup Active Jobs that will store all jobs currently in process
 	ac := jobs.ActiveJobs{}
 	ac.Jobs = make(map[string]*jobs.Job)

--- a/api/handlers/config.go
+++ b/api/handlers/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"text/template"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -75,7 +76,9 @@ func NewRESTHander(pluginsDir string, dbPath string) *RESTHandler {
 
 	// Read all the html templates
 	funcMap := template.FuncMap{
-		"prettyPrint": prettyPrint, // to pretty pring JSONs for results and metadata
+		"prettyPrint": prettyPrint, // to pretty print JSONs for results and metadata
+		"lower":       strings.ToLower,
+		"upper":       strings.ToUpper,
 	}
 
 	config.T = Template{

--- a/api/jobs/database.go
+++ b/api/jobs/database.go
@@ -96,7 +96,7 @@ func (db *DB) updateJobRecord(jid string, status string, now time.Time) {
 
 // Get Job Record from database given a job id.
 // If job do not exists, or error encountered bool would be false.
-// Similar behaviour as key exist in hashmap.
+// Similar behavior as key exist in hashmap.
 func (db *DB) GetJob(jid string) (JobRecord, bool) {
 	query := `SELECT * FROM jobs WHERE id = ?`
 

--- a/api/jobs/docker_jobs.go
+++ b/api/jobs/docker_jobs.go
@@ -3,6 +3,7 @@ package jobs
 import (
 	"app/controllers"
 	"app/utils"
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/sirupsen/logrus"
 )
 
 type DockerJob struct {
@@ -30,8 +32,10 @@ type DockerJob struct {
 	Cmd            []string `json:"commandOverride"`
 	UpdateTime     time.Time
 	Status         string `json:"status"`
-	apiLogs        []string
-	containerLogs  []string
+
+	logger  *logrus.Logger
+	logFile *os.File
+
 	Resources
 	DB         *DB
 	StorageSvc *s3.S3
@@ -62,26 +66,65 @@ func (j *DockerJob) IMAGE() string {
 	return j.Image
 }
 
-// Return current logs of the job
-func (j *DockerJob) Logs() (logs JobLogs, err error) {
-	err = j.fetchContainerLogs()
-	if err != nil {
+// Update container logs
+func (j *DockerJob) UpdateContainerLogs() (err error) {
+	// If old status is one of the terminated status, close has already been called and container logs fetched, container killed
+	switch j.Status {
+	case SUCCESSFUL, DISMISSED, FAILED:
 		return
 	}
 
-	logs.JobID = j.UUID
-	logs.ProcessID = j.ProcessName
-	logs.ContainerLogs = j.containerLogs
-	logs.APILogs = j.apiLogs
-	return logs, nil
+	j.logger.Info("updating container logs")
+	containerLogs, err := j.fetchContainerLogs()
+	if err != nil {
+		j.logger.Error(err.Error())
+		return
+	}
+
+	if len(containerLogs) == 0 || containerLogs == nil {
+		return
+	}
+
+	// Create a new file or overwrite if it exists
+	file, err := os.Create(fmt.Sprintf("%s/%s.container.jsonl", os.Getenv("LOCAL_LOGS_DIR"), j.UUID))
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	writer := bufio.NewWriter(file)
+	defer writer.Flush()
+
+	for i, line := range containerLogs {
+		if i != len(containerLogs)-1 {
+			_, err = writer.WriteString(line + "\n")
+		} else {
+			_, err = writer.WriteString(line)
+		}
+	}
+
+	return
 }
 
-func (j *DockerJob) Messages(includeErrors bool) []string {
-	return j.apiLogs
-}
-
-func (j *DockerJob) NewMessage(m string) {
-	j.apiLogs = append(j.apiLogs, m)
+func (j *DockerJob) LogMessage(m string, level logrus.Level) {
+	switch level {
+	// case 1:
+	// 	j.logger.Panic(m)
+	// case 2:
+	// 	j.logger.Fatal(m)
+	case 3:
+		j.logger.Error(m)
+	case 4:
+		j.logger.Warn(m)
+	case 5:
+		j.logger.Info(m)
+	case 6:
+		j.logger.Debug(m)
+	case 7:
+		j.logger.Trace(m)
+	default:
+		j.logger.Info(m) // default to Info level if level is out of range
+	}
 }
 
 func (j *DockerJob) LastUpdate() time.Time {
@@ -97,6 +140,7 @@ func (j *DockerJob) NewStatusUpdate(status string, updateTime time.Time) {
 	}
 
 	j.Status = status
+	j.logger.Info("status changed to ", status)
 	if updateTime.IsZero() {
 		j.UpdateTime = time.Now()
 	} else {
@@ -122,13 +166,41 @@ func (j *DockerJob) Equals(job Job) bool {
 	}
 }
 
+func (j *DockerJob) initLogger() error {
+	// Create a place holder file for container logs
+	file, err := os.OpenFile(fmt.Sprintf("%s/%s.container.jsonl", os.Getenv("LOCAL_LOGS_DIR"), j.UUID), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	if err != nil {
+		return fmt.Errorf("failed to open log file: %s", err.Error())
+	}
+	file.Close()
+
+	// Create logger for server logs
+	j.logger = logrus.New()
+
+	file, err = os.OpenFile(fmt.Sprintf("%s/%s.server.jsonl", os.Getenv("LOCAL_LOGS_DIR"), j.UUID), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	if err != nil {
+		return fmt.Errorf("failed to open log file: %s", err.Error())
+	}
+
+	j.logger.SetOutput(file)
+	j.logger.SetFormatter(&logrus.JSONFormatter{})
+	j.logger.SetLevel(logrus.InfoLevel)
+	return nil
+}
+
 func (j *DockerJob) Create() error {
+
+	err := j.initLogger()
+	if err != nil {
+		return err
+	}
+
 	ctx, cancelFunc := context.WithCancel(context.TODO())
 	j.ctx = ctx
 	j.ctxCancel = cancelFunc
 
 	// At this point job is ready to be added to database
-	err := j.DB.addJob(j.UUID, "accepted", time.Now(), "", "local", j.ProcessName)
+	err = j.DB.addJob(j.UUID, "accepted", time.Now(), "", "local", j.ProcessName)
 	if err != nil {
 		j.ctxCancel()
 		return err
@@ -146,7 +218,7 @@ func (j *DockerJob) Run() {
 	isCancelled := func() bool {
 		select {
 		case <-j.ctx.Done():
-			j.NewMessage("Context cancelled")
+			j.logger.Info("Context cancelled")
 			return true
 		default:
 			return false
@@ -164,7 +236,7 @@ func (j *DockerJob) Run() {
 
 	c, err := controllers.NewDockerController()
 	if err != nil {
-		j.NewMessage("Failed creating NewDockerController. Error: " + err.Error())
+		j.logger.Info("Failed creating NewDockerController. Error: " + err.Error())
 		j.NewStatusUpdate(FAILED, time.Time{})
 		return
 	}
@@ -175,14 +247,14 @@ func (j *DockerJob) Run() {
 		envVars[eVar] = os.Getenv(eVar)
 	}
 
-	j.NewMessage(fmt.Sprintf("Registered %v env vars", len(envVars)))
+	j.logger.Info(fmt.Sprintf("Registered %v env vars", len(envVars)))
 	resources := controllers.DockerResources{}
 	resources.NanoCPUs = int64(j.Resources.CPUs * 1e9)         // Docker controller needs cpu in nano ints
 	resources.Memory = int64(j.Resources.Memory * 1024 * 1024) // Docker controller needs memory in bytes
 
 	err = c.EnsureImage(j.ctx, j.Image, false)
 	if err != nil {
-		j.NewMessage(fmt.Sprintf("Could not ensure image %s available", j.Image))
+		j.logger.Info(fmt.Sprintf("Could not ensure image %s available", j.Image))
 		j.NewStatusUpdate(FAILED, time.Time{})
 		return
 	}
@@ -190,7 +262,7 @@ func (j *DockerJob) Run() {
 	// start container
 	containerID, err := c.ContainerRun(j.ctx, j.Image, j.Cmd, []controllers.VolumeMount{}, envVars, resources)
 	if err != nil {
-		j.NewMessage("Failed to run container. Error: " + err.Error())
+		j.logger.Error("Failed to run container. Error: ", err.Error())
 		j.NewStatusUpdate(FAILED, time.Time{})
 		return
 	}
@@ -206,25 +278,25 @@ func (j *DockerJob) Run() {
 	exitCode, err := c.ContainerWait(j.ctx, j.ContainerID)
 	if err != nil {
 
-		j.NewMessage("Failed waiting for container to finish. Error: " + err.Error())
+		j.logger.Info("Failed waiting for container to finish. Error: " + err.Error())
 		j.NewStatusUpdate(FAILED, time.Time{})
 		return
 	}
 
 	if exitCode != 0 {
-		j.NewMessage(fmt.Sprintf("Container failure, exit code: %d ", exitCode))
+		j.logger.Info(fmt.Sprintf("Container failure, exit code: %d ", exitCode))
 		j.NewStatusUpdate(FAILED, time.Time{})
 		return
 	}
 
-	j.NewMessage("Container process finished successfully.")
+	j.logger.Info("Container process finished successfully.")
 	j.NewStatusUpdate(SUCCESSFUL, time.Time{})
 	go j.WriteMetaData()
 }
 
 // kill local container
 func (j *DockerJob) Kill() error {
-	j.NewMessage("Received dismiss signal")
+	j.logger.Info("Received dismiss signal")
 	switch j.CurrentStatus() {
 	case SUCCESSFUL, FAILED, DISMISSED:
 		// if these jobs have been loaded from previous snapshot they would not have context etc
@@ -243,20 +315,20 @@ func (j *DockerJob) Kill() error {
 
 // Write metadata at the job's metadata location
 func (j *DockerJob) WriteMetaData() {
-	j.NewMessage("Starting metadata writing routine.")
+	j.logger.Info("Starting metadata writing routine.")
 	j.wg.Add(1)
 	defer j.wg.Done()
-	defer j.NewMessage("Finished metadata writing routine.")
+	defer j.logger.Info("Finished metadata writing routine.")
 
 	c, err := controllers.NewDockerController()
 	if err != nil {
-		j.NewMessage("Could not create controller. Error: " + err.Error())
+		j.logger.Info("Could not create controller. Error: " + err.Error())
 	}
 
 	p := process{j.ProcessID(), j.ProcessVersionID()}
 	imageDigest, err := c.GetImageDigest(j.IMAGE())
 	if err != nil {
-		j.NewMessage(fmt.Sprintf("Error getting imageDigest: %s", err.Error()))
+		j.logger.Info(fmt.Sprintf("Error getting imageDigest: %s", err.Error()))
 		return
 	}
 
@@ -264,7 +336,7 @@ func (j *DockerJob) WriteMetaData() {
 
 	g, s, e, err := c.GetJobTimes(j.ContainerID)
 	if err != nil {
-		j.NewMessage(fmt.Sprintf("Error getting jobtimes: %s", err.Error()))
+		j.logger.Info(fmt.Sprintf("Error getting jobtimes: %s", err.Error()))
 		return
 	}
 
@@ -281,7 +353,7 @@ func (j *DockerJob) WriteMetaData() {
 
 	jsonBytes, err := json.Marshal(md)
 	if err != nil {
-		j.NewMessage(fmt.Sprintf("Error marshalling metadata: %s", err.Error()))
+		j.logger.Info(fmt.Sprintf("Error marshalling metadata: %s", err.Error()))
 		return
 	}
 
@@ -294,30 +366,29 @@ func (j *DockerJob) WriteMetaData() {
 }
 
 // func (j *DockerJob) WriteResults(data []byte) (err error) {
-// 	j.NewMessage("Starting results writing routine.")
-// 	defer j.NewMessage("Finished results writing routine.")
+// 	j.logger.Info("Starting results writing routine.")
+// 	defer j.logger.Info("Finished results writing routine.")
 
 // 	resultsDir := os.Getenv("STORAGE_RESULTS_DIR")
 // 	resultsLocation := fmt.Sprintf("%s/%s.json", resultsDir, j.UUID)
 // 	fmt.Println(resultsLocation)
 // 	err = utils.WriteToS3(j.StorageSvc, data, resultsLocation, "application/json", 0)
 // 	if err != nil {
-// 		j.NewMessage(fmt.Sprintf("error writing results to storage: %v", err.Error()))
+// 		j.logger.Info(fmt.Sprintf("error writing results to storage: %v", err.Error()))
 // 	}
 // 	return
 // }
 
-func (j *DockerJob) fetchContainerLogs() error {
+func (j *DockerJob) fetchContainerLogs() ([]string, error) {
 	c, err := controllers.NewDockerController()
 	if err != nil {
-		return fmt.Errorf("could not create controller to fetch container logs")
+		return nil, fmt.Errorf("could not create controller to fetch container logs")
 	}
 	containerLogs, err := c.ContainerLog(context.TODO(), j.ContainerID)
 	if err != nil {
-		return fmt.Errorf("could not fetch container logs")
+		return nil, fmt.Errorf("could not fetch container logs")
 	}
-	j.containerLogs = containerLogs
-	return nil
+	return containerLogs, nil
 }
 
 func (j *DockerJob) RunFinished() {
@@ -327,28 +398,58 @@ func (j *DockerJob) RunFinished() {
 
 // Write final logs, cancelCtx
 func (j *DockerJob) Close() {
+
+	j.logger.Info("starting closing routine")
 	// to do: add panic recover to remove job from active jobs even if following panics
 	j.ctxCancel() // Signal Run function to terminate if running
 
 	if j.ContainerID != "" { // Container related cleanups if container exists
 		c, err := controllers.NewDockerController()
 		if err != nil {
-			j.NewMessage("Could not create controller. Error: " + err.Error())
+			j.logger.Info("Could not create controller. Error: " + err.Error())
 		} else {
 			containerLogs, err := c.ContainerLog(context.TODO(), j.ContainerID)
 			if err != nil {
-				j.NewMessage("Could not fetch container logs. Error: " + err.Error())
+				j.logger.Error("Could not fetch container logs. Error: " + err.Error())
 			}
-			j.containerLogs = containerLogs
+
+			file, err := os.Create(fmt.Sprintf("%s/%s.container.jsonl", os.Getenv("LOCAL_LOGS_DIR"), j.UUID))
+			if err != nil {
+				j.logger.Error("could not create container logs file")
+				return
+			}
+
+			writer := bufio.NewWriter(file)
+
+			for i, line := range containerLogs {
+				if i != len(containerLogs)-1 {
+					_, err = writer.WriteString(line + "\n")
+				} else {
+					_, err = writer.WriteString(line)
+				}
+				if err != nil {
+					j.logger.Errorf("could not write log %s to file", line)
+				}
+			}
+
+			writer.Flush()
+			file.Close()
 
 			err = c.ContainerRemove(context.TODO(), j.ContainerID)
 			if err != nil {
-				j.NewMessage("Could not remove container. Error: " + err.Error())
+				j.logger.Info("Could not remove container. Error: " + err.Error())
 			}
 		}
 	}
-	j.wg.Wait() // wait if other routines like metadata are running
-	// this should be completed before job is sent to Done because logs are handled differently for active and unactive jobs
-	j.DB.upsertLogs(j.UUID, j.ProcessID(), j.apiLogs, j.containerLogs)
 	j.DoneChan <- j // At this point job can be safely removed from active jobs
+	j.wg.Wait()     // wait if other routines like metadata are running
+	j.logFile.Close()
+	go func() {
+		UploadLogsToStorage(j.StorageSvc, j.UUID, j.ProcessName)
+		// It is expected that logs will be requested multiple times for a recently finished job
+		// so we are waiting for one hour to before deleting the local copy
+		// so that we can avoid repetitive request to storage service
+		time.Sleep(time.Hour)
+		DeleteLocalLogs(j.StorageSvc, j.UUID, j.ProcessName)
+	}()
 }

--- a/api/jobs/jobs.go
+++ b/api/jobs/jobs.go
@@ -91,7 +91,7 @@ func DecodeLogStrings(s []string) []LogEntry {
 		}
 		var log LogEntry
 		err := json.Unmarshal([]byte(s), &log)
-		if err != nil {
+		if err != nil || (log.Msg == "" && s != "") { // incase log is not valid JSON or log is valid but does not have msg field or have other fields
 			log = LogEntry{Msg: s}
 		}
 		if log.Msg != "" {

--- a/api/jobs/jobs.go
+++ b/api/jobs/jobs.go
@@ -275,7 +275,7 @@ func FetchLogs(svc *s3.S3, jid, pid string) (JobLogs, error) {
 		if !exists {
 			return JobLogs{}, fmt.Errorf("%s log file not found on storage", k.key)
 		}
-		logs, err := utils.GetS3LinesData(k.key, svc)
+		logs, err := utils.GetS3LinesData(storageKey, svc)
 		if err != nil {
 			return JobLogs{}, fmt.Errorf("failed to read %s logs from storage: %v", k.key, err)
 		}

--- a/api/public/css/main.css
+++ b/api/public/css/main.css
@@ -19,6 +19,11 @@
     --code-bg-color: #ffffff;
     --status-client-error-color: #925f00;
     --status-server-error-color: #d00000;
+
+    --log-warning: var(--status-client-error-color);
+    --log-error: var(--status-server-error-color);
+    --log-debug: cyan;
+    --log-info: green;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -43,6 +48,11 @@
         --code-bg-color: #000000;
         --status-client-error-color: orange;
         --status-server-error-color: red;
+
+        --log-warning: orange;
+        --log-error: red;
+        --log-debug: #00BFFF; /* deep sky blue */
+        --log-info: #00c100; /* lime green */
     }
 }
 
@@ -170,4 +180,21 @@ code[class*="language-"] {
     background-color: var(--code-bg-color);
     font-family: monospace;
     /* Monospaced font */
+}
+
+/* CSS Classes for Log Levels */
+.log-warning {
+    color: var(--log-warning);
+}
+
+.log-error {
+    color: var(--log-error);
+}
+
+.log-debug {
+    color: var(--log-debug);
+}
+
+.log-info {
+    color: var(--log-info);
 }

--- a/api/utils/utils.go
+++ b/api/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"io"
@@ -104,4 +105,32 @@ func GetS3JsonData(key string, svc *s3.S3) (interface{}, error) {
 	}
 
 	return data, nil
+}
+
+// Assumes file exist
+func GetS3LinesData(key string, svc *s3.S3) ([]string, error) {
+	// Create a new S3GetObjectInput object to specify the file you want to read
+	params := &s3.GetObjectInput{
+		Bucket: aws.String(os.Getenv("STORAGE_BUCKET")),
+		Key:    aws.String(key),
+	}
+
+	// Use the S3 service object to download the file into a byte slice
+	resp, err := svc.GetObject(params)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return lines, nil
 }

--- a/api/views/jobLogs.html
+++ b/api/views/jobLogs.html
@@ -10,23 +10,48 @@
 
 <body>
     <h1>Logs · {{.JobID}}</h1>
-    <h2>{{.ProcessID}}</h2>
+    <h2>Process: {{.ProcessID}}</h2>
+
     <h3>Server Logs</h3>
     <table>
-        {{range .ServerLogs}}
-        <tr>
-            <td>{{.}}</td>
-        </tr>
-        {{end}}
+        <thead>
+            <tr>
+                <th>Time</th>
+                <th>Level</th>
+                <th>Message</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range .ServerLogs}}
+            <tr>
+                <td>{{.Time.Format "2006-01-02 15:04:05 MST"}}</td>
+                <td class="log-{{.Level | lower}}">{{.Level | upper}}</td>
+                <td>{{.Msg}}</td>
+            </tr>
+            {{end}}
+        </tbody>
     </table>
+
     <h3>Container Logs</h3>
     <table>
-        {{range .ContainerLogs}}
-        <tr>
-            <td>{{.}}</td>
-        </tr>
-        {{end}}
+        <thead>
+            <tr>
+                <th>Time</th>
+                <th>Level</th>
+                <th>Message</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range .ContainerLogs}}
+            <tr>
+                <td>{{.Time.Format "2006-01-02 15:04:05 MST"}}</td>
+                <td class="log-{{.Level | lower}}">{{.Level | upper}}</td>
+                <td>{{.Msg}}</td>
+            </tr>
+            {{end}}
+        </tbody>
     </table>
+
 </body>
 
 </html>

--- a/api/views/jobLogs.html
+++ b/api/views/jobLogs.html
@@ -11,9 +11,9 @@
 <body>
     <h1>Logs · {{.JobID}}</h1>
     <h2>{{.ProcessID}}</h2>
-    <h3>API Logs</h3>
+    <h3>Server Logs</h3>
     <table>
-        {{range .APILogs}}
+        {{range .ServerLogs}}
         <tr>
             <td>{{.}}</td>
         </tr>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
     volumes:
       - ./api:/app
       - ./.data:/.data
-      - ./data:/data
       - /var/run/docker.sock:/var/run/docker.sock
     networks:
       - process_api_net

--- a/tests/e2e/tests.postman_collection.json
+++ b/tests/e2e/tests.postman_collection.json
@@ -1010,7 +1010,7 @@
 													"listen": "prerequest",
 													"script": {
 														"exec": [
-															"setTimeout(() => {}, 5000); \r",
+															"setTimeout(() => {}, 20000); \r",
 															""
 														],
 														"type": "text/javascript"


### PR DESCRIPTION
Revamp the logging mechanism to:
- Write server logs using `logrous` 
- Write logs to storage rather than Database
- Format logs by fields
- Colorize logs by level

Before:
![image](https://github.com/Dewberry/process-api/assets/53625184/96f8794f-9e19-4a7e-8c18-75807ce26747)


After
![image](https://github.com/Dewberry/process-api/assets/53625184/5f056965-d794-417a-8785-b4a878c4a1ec)
