### PR TITLE
Fix log stream name capture when job was failing

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -18,4 +18,8 @@
 - Only service_accounts can post callbacks
 - Requests from Admin Role are allowed to execute all processes, non-admins must have the role with same name as `processID` to execute that process.
 - Requests from Admin Role are allowed to retrieve all jobs information, non admins can only retrieve information for jobs that they submitted.
-- Only admins can add/update/delete processes
+- Only admins can add/update/delete processes.
+
+
+## Scope
+- The behavior of logging is unknown for AWS Batch processes with job definitions having number of attempts more than 1.

--- a/api/controllers/aws_batch.go
+++ b/api/controllers/aws_batch.go
@@ -129,17 +129,15 @@ func (c *AWSBatchController) JobMonitor(batchID string) (string, string, error) 
 	status := aws.StringValue(output.Jobs[0].Status)
 	lsn := aws.StringValue(output.Jobs[0].Container.LogStreamName)
 
-	if status == "FAILED" {
+	switch status {
+	case "FAILED":
 		reason := aws.StringValue(output.Jobs[0].StatusReason)
 		// Non-standard reason used here to facilitate ogc implementation
 		if reason == "DISMISSED" {
 			return reason, lsn, nil
 		} else {
-			return status, lsn, fmt.Errorf("aws provided StatusReason for failure: %s", reason)
+			return status, lsn, nil
 		}
-	}
-
-	switch status {
 	case "SUBMITTED":
 		return "ACCCEPTED", lsn, nil
 	case "PENDING":
@@ -149,12 +147,12 @@ func (c *AWSBatchController) JobMonitor(batchID string) (string, string, error) 
 	case "STARTING":
 		return "RUNNING", lsn, nil
 	case "RUNNING":
-		return "RUNNING", lsn, nil
+		return status, lsn, nil
 	case "SUCCEEDED":
-		return "SUCCEEDED", lsn, nil
+		return status, lsn, nil
 
 	default:
-		return status, lsn, fmt.Errorf("unrecognized status  %s", status)
+		return "", lsn, fmt.Errorf("unrecognized status  %s", status)
 	}
 }
 

--- a/api/handlers/handlers.go
+++ b/api/handlers/handlers.go
@@ -493,18 +493,16 @@ func (rh *RESTHandler) JobLogsHandler(c echo.Context) (err error) {
 		return err
 	}
 
-	var pid string
+	var pid, status string
 	var jRcrd jobs.JobRecord
 
 	if job, ok := rh.ActiveJobs.Jobs[jobID]; ok { // ActiveJobs hit
-		err = (*job).UpdateContainerLogs()
-		if err != nil {
-			output := errResponse{HTTPStatus: http.StatusInternalServerError, Message: "error while updating container logs: " + err.Error()}
-			return prepareResponse(c, http.StatusInternalServerError, "error", output)
-		}
+		_ = (*job).UpdateContainerLogs()
 		pid = (*job).ProcessID()
+		status = (*job).CurrentStatus()
 	} else if jRcrd, ok, err = rh.DB.GetJob(jobID); ok { // db hit
 		pid = jRcrd.ProcessID
+		status = jRcrd.Status
 	} else { // miss
 		output := errResponse{HTTPStatus: http.StatusNotFound, Message: "jobID not found"}
 		return prepareResponse(c, http.StatusNotFound, "error", output)
@@ -515,12 +513,14 @@ func (rh *RESTHandler) JobLogsHandler(c echo.Context) (err error) {
 		return prepareResponse(c, http.StatusInternalServerError, "error", output)
 	}
 
-	logs, err := jobs.FetchLogs(rh.StorageSvc, jobID, pid, false)
+	logs, err := jobs.FetchLogs(rh.StorageSvc, jobID, false)
 	if err != nil {
 		output := errResponse{HTTPStatus: http.StatusInternalServerError, Message: "error while fetching logs: " + err.Error()}
 		return prepareResponse(c, http.StatusInternalServerError, "error", output)
 	}
 
+	logs.ProcessID = pid
+	logs.Status = status
 	return prepareResponse(c, http.StatusOK, "jobLogs", logs)
 
 }

--- a/api/views/jobLogs.html
+++ b/api/views/jobLogs.html
@@ -9,7 +9,18 @@
 </head>
 
 <body>
-    <h1>Logs · {{.JobID}}</h1>
+    <h1>
+        Logs · {{.JobID}}
+        {{if eq .Status "successful"}}
+        <img src="/public/svgs/check-icon.svg" alt="successful" />
+        {{else if eq .Status "failed"}}
+        <img src="/public/svgs/cross-icon.svg" alt="failed" />
+        {{else if eq .Status "dismissed"}}
+        <img src="/public/svgs/delete-icon.svg" alt="dismissed" />
+        {{else if or (eq .Status "accepted") (eq .Status "running")}}
+        <img src="/public/svgs/yellow-circle-icon.svg" alt="in progress" />
+        {{end}}
+    </h1>
     <h2>Process: {{.ProcessID}}</h2>
 
     <h3>Server Logs</h3>

--- a/api/views/statusTable.html
+++ b/api/views/statusTable.html
@@ -20,6 +20,7 @@
             <img src="/public/svgs/yellow-circle-icon.svg" alt="in progress" />
             {{end}}
             {{.Status}}
+        </td>
     </tr>
     <tr>
         <td class="bold">Last Updated</td>


### PR DESCRIPTION
- Fix the log stream name not being captured when the job has failed
- Return logs response even when there is an error in updating container logs
- Make `/logs` only available after the job is running
- Improve logging for AWS jobs






